### PR TITLE
script: add script to generate reproducible yearly feeds

### DIFF
--- a/scripts/mk-feed
+++ b/scripts/mk-feed
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+# (C) Yann E. MORIN <yann.morin.1998@free.fr>
+# Licese: Public Domain or CC-0, at your option
+
+import argparse
+import contextlib
+import datetime
+import gzip
+import hashlib
+import json
+import lzma
+import os
+import subprocess
+
+description = """Generate yearly feeds of CVE."""
+
+epilog = """This script needs to run from a working copy of the git
+repository. It walks all the individual CVEs, and agregates them in
+yearly feeds. The uncompressed feeds are reproducible. The compressed
+archives may or may not be reproducible, although their content is;
+the gz archives are known not to be reproducible.
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=description,
+        epilog=epilog,
+    )
+    parser.add_argument(
+        "DEST_DIR",
+        help="Output yearly feeds in this directory, which is created first.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="By Default, DEST_DIR must not already exist, use --force to use an existing directory",
+    )
+    parser.add_argument(
+        "--compress",
+        action="store",
+        default="xz",
+        choices=["none", "gz", "xz"],
+        help=f"Compress the feeds (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    try:
+        os.makedirs(args.DEST_DIR, exist_ok=args.force)
+    except OSError:
+        if args.force:
+            raise
+        parser.error(f"{args.DEST_DIR}: directory exists; use --force maybe?")
+
+    year_begin = 1999
+    year_now = datetime.datetime.now(datetime.UTC).year
+    git_log = ["git", "log", "-n", "1", "--pretty=tformat:%cI"]
+    git_log_p = subprocess.Popen(
+        args=git_log,
+        stdout=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+    )
+    git_log_p.wait()
+    if git_log_p.returncode:
+        raise RuntimeError(
+            f"Error executing {" ".join(git_log)}: returned {git_log_p.returncode}",
+        )
+    commit_date = git_log_p.stdout.readlines()[0].decode()
+    nb_feeds = 0
+    nb_cves = 0
+    for year in range(year_begin, year_now+1):
+        print(f"\r\33[KScanning {year}...", end="", flush=True)
+        cve_items = list()
+        latest_modified = None
+        for dirpath, _, filenames in os.walk(f"CVE-{year}"):
+            for filename in filenames:
+                with open(os.path.join(dirpath, filename), "r") as f:
+                    cve = json.load(f)
+                cve_items.append(cve)
+                cve_modified_str = cve["lastModified"]
+                cve_modified = datetime.datetime.fromisoformat(cve_modified_str)
+                if latest_modified is None or cve_modified > latest_modified:
+                    latest_modified_str = cve_modified_str
+                    latest_modified = cve_modified
+        print(f" {len(cve_items)} CVEs", end="", flush=True)
+        nb_feeds += 1
+        nb_cves += len(cve_items)
+        cve_feed = {
+            "timestamp": commit_date,
+            "cve_count": len(cve_items),
+            "feed_name": f"CVE-{year}",
+            "source": "fkie-cad/nvd-json-data-feeds",
+            "cve_items": sorted(cve_items, key=lambda c: cve_id_key(c["id"])),
+        }
+        year_feed = json.dumps(cve_feed, indent=2)
+        with open_feed(
+            os.path.join(args.DEST_DIR, f"CVE-{year}.json"),
+            compress=args.compress,
+        ) as feed:
+            feed_file = feed[1]
+            feed[0].write(year_feed.encode())
+        with open(os.path.join(args.DEST_DIR, f"CVE-{year}.meta"), "w") as meta:
+            meta.write(f"lastModifiedDate:{latest_modified_str}\n")
+            meta.write(f"size:{len(year_feed)}\n")
+            if args.compress != "none":
+                meta.write(
+                    f"{args.compress}Size:{os.stat(feed_file).st_size}\n",
+                )
+            # Note: no \n on the last line for legacy reasons...
+            meta.write(
+                f"sha256:{hashlib.sha256(year_feed.encode()).hexdigest()}",
+            )
+    print(f"\r\33[KGenerated {nb_feeds} feeds, with {nb_cves} CVEs total.")
+
+
+@contextlib.contextmanager
+def open_feed(base_path, compress):
+    try:
+        if compress == "none":
+            name = base_path
+            f = open(
+                name,
+                mode="wb",
+            )
+        elif compress == "xz":
+            name = f"{base_path}.xz"
+            f = lzma.open(
+                name,
+                mode="wb",
+                format=lzma.FORMAT_XZ,
+                preset=6,
+            )
+        else:
+            name = f"{base_path}.gz"
+            f = gzip.open(
+                name,
+                mode="wb",
+                compresslevel=6,
+            )
+        yield (f, name)
+    finally:
+        f.close()
+
+
+def cve_id_key(cve_id):
+    year, id_ = cve_id.split('-')[1:]
+    return (int(year), int(id_))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
As discussed in #1, here's a litle script that can generate
the yearly feeds, in case it can help in any way.

Having the script in the same repo as the CVE files themselves,
guarantees (to some extent, of course) that the script will be
kept up to date with any format change in the CVE files. Also,
there is no question about what the version of the script to use
is, for each commit in the repo: the script is there, so that is
what to use.